### PR TITLE
Add build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: "Build packages"
+
+on:
+  push:
+    branches: 
+      - master
+
+  schedule:
+  - cron: "0 20 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: 
+          - "bionic"
+          - "centos8"
+          - "buster"
+          - "centos7"
+          - "stretch"
+          - "jessie"
+          - "xenial"
+          - "trusty"
+          - "eoan"
+          - "disco"
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.x'
+
+    - name: Build and package for ${{ matrix.distro }}
+      run: |
+        ruby setup.rb --packages --distro ${{ matrix.distro }}
+    - uses: actions/upload-artifact@master
+      name: Stash ${{ matrix.distro }} artifacts
+      with:
+        name: Build artifacts
+        path: artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,5 +38,5 @@ jobs:
     - uses: actions/upload-artifact@master
       name: Stash ${{ matrix.distro }} artifacts
       with:
-        name: Build artifacts
+        name: ${{ matrix.distro }} build artifacts
         path: artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/setup.rb
+++ b/setup.rb
@@ -52,6 +52,9 @@ support_commit = options[:support_commit]
 build_args = "--build-arg commit=#{commit} --build-arg support_commit=#{support_commit}"
 build_args_support = "--build-arg commit=#{support_commit}"
 
+artifact_dir = "artifacts"
+Dir.mkdir(artifact_dir) unless File.directory?(artifact_dir)
+
 # distros is in order of priority.
 distros = [
 # latest production releases
@@ -111,6 +114,9 @@ if options[:support]
         Dir.chdir("#{distro}/package") {
           system "docker build -t samrhughes/rdb-#{distro}-package:#{commit} #{build_args} ." or raise "build rdb-#{distro}-package fail"
         }
+
+        # Extract artifacts from the build container
+        system "docker run -v ${PWD}:/opt/mount --rm --entrypoint tar samrhughes/rdb-#{distro}-package:#{commit} -czvf /opt/mount/#{artifact_dir}/#{distro}.tar.gz /platform/rethinkdb/build/packages" or raise "build rdb-#{distro}-package fail"
       }
     end
   end


### PR DESCRIPTION
Add build pipeline implemented as GitHub actions. The current solution build all the packages in parallel and tolerate failures. The produced packages are uploaded as artifacts which can be downloaded per build as gzip archives.

The pipeline runs every day at 20:00 UTC and on every push on master.

![B33B73FD-285B-4809-A0C9-6C330896E4E1](https://user-images.githubusercontent.com/19173947/68958938-6573cf00-07cd-11ea-88b1-66df4fc93812.png)
