### PR TITLE
FFI gem now requires Ruby >= 2.3

### DIFF
--- a/centos7/system/Dockerfile
+++ b/centos7/system/Dockerfile
@@ -9,7 +9,7 @@ RUN yum install -y openssl-devel libcurl-devel wget tar m4 \
     protobuf-devel protobuf-static jemalloc-devel \
     bzip2 patch \
     perl rubygems ruby-devel rpm-build
-RUN gem install fpm
+RUN gem install ffi -v 1.12.0 && gem install fpm
 
 RUN mkdir /platform
 


### PR DESCRIPTION
FFI gem now requires Ruby >= 2.3 and in FPM the FFI gem is not pinned.
This results in a situation when FPM cannot be installed because of the new FFI gem.
By pinning FFI to the latest working version, the problem goes away.